### PR TITLE
Large matrix routing

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -60,10 +60,11 @@ set_verbose <- function(ans = FALSE) {
   }
 }
 
-#' Limit requests to the APIs
+#' Set whether plan is freemium or not
 #'
 #' If set to \code{TRUE} the hereR package limits the requests per second (RPS)
-#' sent to the APIs. This option is necessary for freemium licenses to avoid
+#' sent to the APIs and routing matrices will be chopped up into submatrices
+#' of size 15x100. This option is necessary for freemium licenses to avoid
 #' hitting the rate limit of the APIs with status code 429. Deactivate this
 #' option to increase speed of requests for paid plans.
 #'
@@ -75,14 +76,14 @@ set_verbose <- function(ans = FALSE) {
 #' @export
 #'
 #' @examples
-#' set_rate_limit(FALSE)
-set_rate_limit <- function(ans = TRUE) {
+#' set_freemium(FALSE)
+set_freemium <- function(ans = TRUE) {
   .check_boolean(ans)
   if (!ans) {
     Sys.setenv(
-      "HERE_RPS" = "FALSE"
+      "HERE_FREEMIUM" = "FALSE"
     )
   } else {
-    Sys.unsetenv("HERE_RPS")
+    Sys.unsetenv("HERE_FREEMIUM")
   }
 }

--- a/R/route_matrix.R
+++ b/R/route_matrix.R
@@ -33,7 +33,7 @@
 #' )
 route_matrix <- function(origin, destination = origin, datetime = Sys.time(),
                          routing_mode = "fast", transport_mode = "car",
-                         traffic = TRUE, freemium = TRUE, url_only = FALSE) {
+                         traffic = TRUE, url_only = FALSE) {
 
   # Checks
   .check_points(origin)
@@ -43,7 +43,6 @@ route_matrix <- function(origin, destination = origin, datetime = Sys.time(),
   .check_transport_mode(transport_mode, request = "matrix")
   .check_boolean(traffic)
   .check_boolean(url_only)
-  .check_boolean(freemium)
 
   # CRS transformation and formatting
   orig_coords <- sf::st_coordinates(
@@ -68,7 +67,7 @@ route_matrix <- function(origin, destination = origin, datetime = Sys.time(),
   request_headers <- .create_request_headers()
 
   # Create URLs for batches, store original ids and format coordinates
-  if (freemium) {
+  if (.get_freemium()) {
     batch_size_orig <- 15
     batch_size_dest <- 100
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,7 +50,7 @@
   .check_internet()
 
   # Check if rate limits are enabled
-  if (!.get_rate_limits()) {
+  if (!.get_freemium()) {
     rps <- Inf
   }
   .verbose_request(url, rps)
@@ -113,8 +113,8 @@
   }
 }
 
-.get_rate_limits <- function() {
-  if (Sys.getenv("HERE_RPS") != "") {
+.get_freemium <- function() {
+  if (Sys.getenv("HERE_FREEMIUM") != "") {
     return(FALSE)
   } else {
     return(TRUE)


### PR DESCRIPTION
Rename the rate-limit-related variable `HERE_RPS` to `HERE_FREEMIUM`, and the functions `hereR::set_rate_limit()` and `.get_freemium()` functions to `hereR::set_freemium()` and `.get_freemium()`, respectively. Change the documentation to reflect the additional purpose of the now `hereR::set_freemium()` function. Use the `HERE_FREEMIUM` variable to determine a plan-specific size of sub-matrices in the `hereR::route_matrix()` function.